### PR TITLE
performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-Manifest.toml
 data/
 plots/*
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,19 @@
 language: julia
 
 os:
-  - osx
   - linux
 
 julia:
   - 1.0
 
+addons:
+  apt:
+    packages:
+      - python3-matplotlib
 
+  
 notifications:
   email: false
 
-jobs:
-  include:
-    - stage: "TestAndDocs"
-      julia: 1.0
-      os: 
-        - linux
-        - osx
-      script:
-        - julia -E 'string("Build folder ", pwd())'
-        - julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/pszufe/SimpleHypergraphs.jl")); Pkg.instantiate(); Pkg.build("HypergraphsYelp"); Pkg.test("HypergraphsYelp"; coverage=true)'
-        - ls */* 
-        - julia -E 'string("Docs folder ", pwd())'
-        - julia --project=docs/ -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/pszufe/SimpleHypergraphs.jl")); Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'        
-        - julia --project=docs/ docs/make.jl        
-        - ls */* 
-
-  
 after_success:
-  - julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/pszufe/SimpleHypergraphs.jl")); cd(Pkg.dir("HypergraphsYelp")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+  - julia -e 'using Pkg; cd(Pkg.dir("HypergraphsYelp")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 
 os:
-  - osx
   - linux
 
 julia:
@@ -11,13 +10,14 @@ julia:
 notifications:
   email: false
 
+script:
+  - julia -E 'string("script folder ", pwd())'
+
 jobs:
   include:
     - stage: "TestAndDocs"
       julia: 1.0
-      os: 
-        - linux
-        - osx
+      os: linux
       script:
         - julia -E 'string("Build folder ", pwd())'
         - julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/pszufe/SimpleHypergraphs.jl")); Pkg.instantiate(); Pkg.build("HypergraphsYelp"); Pkg.test("HypergraphsYelp"; coverage=true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,22 @@ julia:
 notifications:
   email: false
 
+jobs:
+  include:
+    - stage: "TestAndDocs"
+      julia: 1.0
+      os: 
+        - linux
+        - osx
+      script:
+        - julia -E 'string("Build folder ", pwd())'
+        - julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/pszufe/SimpleHypergraphs.jl")); Pkg.instantiate(); Pkg.build("HypergraphsYelp"); Pkg.test("HypergraphsYelp"; coverage=true)'
+        - ls */* 
+        - julia -E 'string("Docs folder ", pwd())'
+        - julia --project=docs/ -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/pszufe/SimpleHypergraphs.jl")); Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'        
+        - julia --project=docs/ docs/make.jl        
+        - ls */* 
+
+  
 after_success:
-  - julia -e 'using Pkg; cd(Pkg.dir("HypergraphsYelp")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+  - julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/pszufe/SimpleHypergraphs.jl")); cd(Pkg.dir("HypergraphsYelp")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,244 @@
+[[ArnoldiMethod]]
+deps = ["DelimitedFiles", "LinearAlgebra", "Random", "SparseArrays", "StaticArrays", "Test"]
+git-tree-sha1 = "2b6845cea546604fb4dca4e31414a6a59d39ddcd"
+uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
+version = "0.0.4"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[ColorTypes]]
+deps = ["FixedPointNumbers", "Random", "Test"]
+git-tree-sha1 = "f73b0e10f2a5756de7019818a41654686da06b09"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.7.5"
+
+[[Colors]]
+deps = ["ColorTypes", "FixedPointNumbers", "InteractiveUtils", "Printf", "Reexport", "Test"]
+git-tree-sha1 = "9f0a0210450acb91c730b730a994f8eef1d3d543"
+uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
+version = "0.9.5"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "49269e311ffe11ac5b334681d212329002a9832a"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.5.1"
+
+[[Compose]]
+deps = ["Base64", "Colors", "DataStructures", "Dates", "IterTools", "JSON", "LinearAlgebra", "Measures", "Printf", "Random", "Requires", "Test", "UUIDs"]
+git-tree-sha1 = "4f396f3aa55d3077a619daa058029cc297573bdd"
+uuid = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
+version = "0.7.2"
+
+[[Conda]]
+deps = ["Compat", "JSON", "VersionParsing"]
+git-tree-sha1 = "b625d802587c2150c279a40a646fba63f9bd8187"
+uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+version = "1.2.0"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
+git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.15.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[FixedPointNumbers]]
+deps = ["Test"]
+git-tree-sha1 = "b8045033701c3b10bf2324d7203404be7aef88ba"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.5.3"
+
+[[GraphPlot]]
+deps = ["ArnoldiMethod", "ColorTypes", "Colors", "Compose", "DelimitedFiles", "LightGraphs", "LinearAlgebra", "Random", "SparseArrays", "Test"]
+git-tree-sha1 = "f4435ce0055d4da938f3bab0c0e523826735c96a"
+uuid = "a2cc645c-3eea-5389-862e-a155d0052231"
+version = "0.3.1"
+
+[[Inflate]]
+deps = ["Pkg", "Printf", "Random", "Test"]
+git-tree-sha1 = "b7ec91c153cf8bff9aff58b39497925d133ef7fd"
+uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
+version = "0.1.1"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IterTools]]
+deps = ["SparseArrays", "Test"]
+git-tree-sha1 = "79246285c43602384e6f1943b3554042a3712056"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.1.1"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.20.0"
+
+[[LaTeXStrings]]
+deps = ["Compat"]
+git-tree-sha1 = "7ab9b8788cfab2bdde22adf9004bda7ad9954b6c"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.0.3"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LightGraphs]]
+deps = ["ArnoldiMethod", "Base64", "DataStructures", "DelimitedFiles", "Distributed", "Inflate", "LinearAlgebra", "Markdown", "Random", "SharedArrays", "SimpleTraits", "SparseArrays", "Statistics", "Test"]
+git-tree-sha1 = "c7222c370d5cf6d4e08ae40bddd8c0db6852dfb1"
+uuid = "093fc24a-ae57-5d10-9952-331d41423f4d"
+version = "1.2.0"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MacroTools]]
+deps = ["Compat"]
+git-tree-sha1 = "3fd1a3022952128935b449c33552eb65895380c1"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.4.5"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Measures]]
+deps = ["Test"]
+git-tree-sha1 = "ddfd6d13e330beacdde2c80de27c1c671945e7d9"
+uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
+version = "0.3.0"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "85619a3f3e17bb4761fe1b1fd47f0e979f964d5b"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.0.2"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[PyCall]]
+deps = ["Compat", "Conda", "MacroTools", "Statistics", "VersionParsing"]
+git-tree-sha1 = "ce4681263f41d98b3faf6107b28284bf8b866f5f"
+uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+version = "1.18.5"
+
+[[PyPlot]]
+deps = ["Colors", "Compat", "LaTeXStrings", "PyCall", "VersionParsing"]
+git-tree-sha1 = "dd9f4a0bba3933f907640a567e1ce2a8ab44c58c"
+uuid = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+version = "2.7.0"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+deps = ["Pkg"]
+git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.2.0"
+
+[[Requires]]
+deps = ["Test"]
+git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "0.5.2"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[SimpleHypergraphs]]
+deps = ["LightGraphs", "Test"]
+git-tree-sha1 = "48401584d1ac1267e20e00692e380583275126bb"
+repo-rev = "master"
+repo-url = "https://github.com/pszufe/SimpleHypergraphs.jl.git"
+uuid = "7558dd50-0253-11e9-0eb7-479a738ce184"
+version = "0.1.0"
+
+[[SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools", "Test"]
+git-tree-sha1 = "c0a542b8d5e369b179ccd296b2ca987f6da5da0a"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.8.0"
+
+[[SimpleWeightedGraphs]]
+deps = ["LightGraphs", "LinearAlgebra", "Markdown", "SparseArrays", "Test"]
+git-tree-sha1 = "8e8a0c6b2193b0b96484a4bba6335d105108fcbc"
+uuid = "47aef6b3-ad0c-573a-a1e2-d07658019622"
+version = "1.1.0"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[StaticArrays]]
+deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
+git-tree-sha1 = "1eb114d6e23a817cd3e99abc3226190876d7c898"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.10.2"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[VersionParsing]]
+deps = ["Compat"]
+git-tree-sha1 = "c9d5aa108588b978bd859554660c8a5c4f2f7669"
+uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
+version = "1.1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,11 @@ authors = ["aleant93 <aless.antelmi@gmail.com>"]
 version = "0.1.0"
 
 [deps]
-Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
-Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
-Fontconfig = "186bb1d3-e1f7-5a2c-a377-96d770f13627"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 GraphPlot = "a2cc645c-3eea-5389-862e-a155d0052231"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-PrintLog = "2f75d321-01b1-5d14-ae48-46ab65b4906f"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 SimpleHypergraphs = "7558dd50-0253-11e9-0eb7-479a738ce184"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+HypergraphsYelp
+===============
+
+Todo

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,5 @@
+using Pkg
+Pkg.add("Documenter")
 using Documenter
 
 
@@ -19,7 +21,7 @@ makedocs(
 	doctest = true
 )
 
-deploydocs(
-    repo ="github.com/aleant93/HypergraphsYelp.jl.git",
-	target="build"
-)
+#deploydocs(
+#    repo ="github.com/aleant93/HypergraphsYelp.jl.git",
+#	target="build"
+#)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ makedocs(
     sitename = "HypergraphsYelp",
     format = Documenter.HTML(),
     modules = [HypergraphsYelp],
-	pages = ["index.md", "reference.md"],
+	pages = ["index.md"],
 	doctest = true
 )
 

--- a/src/HypergraphsYelp.jl
+++ b/src/HypergraphsYelp.jl
@@ -1,4 +1,3 @@
-__precompile__()
 """
 
 """
@@ -9,8 +8,7 @@ using SimpleHypergraphs, SimpleWeightedGraphs
 using LightGraphs
 using PyPlot
 using GraphPlot
-using Juno
-
+using Dates
 
 
 export Business, User, Review, Model

--- a/src/analyzer.jl
+++ b/src/analyzer.jl
@@ -1,8 +1,8 @@
 
 function plotBusinessByCategories(model::Model)
 
-    data = Dict{String,Int64}()
-    maxs = Dict{String,Int64}()
+    data = Dict{Symbol,Int64}()
+    maxs = Dict{Symbol,Int64}()
 
     for business in values(model.businesses)
         for category in business.categories
@@ -90,7 +90,7 @@ end
 
 function plotBusinessByStars(model::Model)
 
-    data = Real[]
+    data = Float64[]
 
     for business in  values(model.businesses)
         push!(data,business.stars)

--- a/src/builder.jl
+++ b/src/builder.jl
@@ -2,9 +2,9 @@
 
 function yelpHG(model::Model)
 
-    h = Hypergraph{Real,Business,Array{Review,1}}(0,0)
+    h = Hypergraph{Float64,Business,Array{Review,1}}(0,0)
 
-    businesses_ids = Dict{AbstractString,Business}()
+    businesses_ids = Dict{Symbol,Business}()
     verticies_ids = Dict{Business,Int}()
     for business in values(model.businesses)
         push!(businesses_ids, business.id=>business)
@@ -14,7 +14,7 @@ function yelpHG(model::Model)
         push!(verticies_ids, business=>v)
     end
 
-    users_review = Dict{AbstractString, Dict{Int, Array{Review,1}}}()
+    users_review = Dict{Symbol, Dict{Int, Array{Review,1}}}()
     for review in values(model.reviews)
         if haskey(businesses_ids,review.business)#IF I DON'T LOAD ALL BUSINESS
 
@@ -48,7 +48,7 @@ function yelpHG(model::Model)
         end
         e = add_hyperedge!(h)
 
-        verticies = Dict{Int,Real}()
+        verticies = Dict{Int,Float64}()
         for v in keys(ureview)
             h[v,e] = 0
         end
@@ -68,7 +68,7 @@ function forecastNumberOfStar(h::Hypergraph)
             hupred+=1
             continue
         end
-        avgs = Real[]
+        avgs = Float64[]
 
         for edge in gethyperedges(h,vertex)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -8,7 +8,7 @@ struct Business
     lng::Float64
     stars::Float64
     reviewcount::Int
-    categories::Array{Symbol}
+    categories::Vector{Symbol}
 end
 
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,39 +1,39 @@
 
 struct Business
-    id::AbstractString
-    name::AbstractString
-    city::AbstractString
-    state::AbstractString
-    lat::Real
-    lng::Real
-    stars::Real
+    id::Symbol
+    name::Symbol
+    city::Symbol
+    state::Symbol
+    lat::Float64
+    lng::Float64
+    stars::Float64
     reviewcount::Int
-    categories::Array{AbstractString}
+    categories::Array{Symbol}
 end
 
 
 struct User
-    id::AbstractString
-    name::AbstractString
+    id::Symbol
     reviewcount::Int
     totcompliment::Int
-    avgstars::Real
-    friends::Vector{AbstractString}
+    avgstars::Float64
+    friends::Vector{Symbol}
 end
 
 struct Review
-    id::AbstractString
-    user::AbstractString
-    business::AbstractString
+    id::Symbol
+    user::Symbol
+    business::Symbol
     stars::Int
-    date::AbstractString
+    date::DateTime
     useful::Int
     funny::Int
     cool::Int
 end
 
+
 struct Model
-    businesses::Dict{String,Business}
-    users::Dict{String,User}
-    reviews::Dict{String,Review}
+    businesses::Dict{Symbol,Business}
+    users::Dict{Symbol,User}
+    reviews::Dict{Symbol,Review}
 end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -90,7 +90,7 @@ function loadReview(io::IO, lines::Int)::Dict{Symbol,Review}
     return result
 end
 
-function nth(what::Char,s::AbstractArray{UInt8},n::Int,reverse = false)
+function nth(what::Char,s::AbstractVector{UInt8},n::Int,reverse = false)
     c = UInt8(what)
     count = 0
     for ix::Int in (reverse ? (length(s):-1:1) : (1:length(s)) )

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,25 +1,24 @@
 
 
 function loadBusiness(io::IO, lines::Int)
-    result = Dict{String,Business}()
+    result = Dict{Symbol,Business}()
     counter = 0
-
     while counter < lines && !eof(io)
         line = readline(io)
         json = JSON.parse(line)
+        id = Symbol(json["business_id"])
         b = Business(
-               json["business_id"],
-               json["name"],
-               json["city"],
-               json["state"],
+               id,
+               Symbol(json["name"]),
+               Symbol(json["city"]),
+               Symbol(json["state"]),
                json["latitude"],
                json["longitude"],
                json["stars"],
                json["review_count"],
-               json["categories"]!=nothing ? map(strip, split(json["categories"],",")) : Vector{String}()
+               json["categories"]!=nothing ? Symbol.(map(strip, split(json["categories"],","))) : Symbol[]
          )
-         push!(result,json["business_id"]=>b)
-
+         result[id] = b
          counter += 1
     end
     return result
@@ -27,7 +26,7 @@ end
 
 
 function loadUsers(io::IO, lines::Int)
-    result = Dict{String,User}()
+    result = Dict{Symbol,User}()
     counter = 0
 
     while counter < lines && !eof(io)
@@ -48,46 +47,58 @@ function loadUsers(io::IO, lines::Int)
             json["compliment_writer"] +
             json["compliment_photos"]
 
+        id = Symbol(json["user_id"])
         b = User(
-            json["user_id"],
-            json["name"],
+            id,
             json["review_count"],
             totcompliments,
             json["average_stars"],
-            json["friends"]!=nothing ?  map(strip, split(json["friends"],",")) : Vector{String}()
+            json["friends"]!=nothing ?  Symbol.(map(strip, split(json["friends"],","))) : Symbol[]
         )
-        push!(result,json["user_id"]=>b)
-
+        result[id]=b
         counter += 1
     end
     return result
 end
 
 
-function loadReview(io::IO, lines::Int)
-    result = Dict{String,Review}()
+function loadReview(io::IO, lines::Int)::Dict{Symbol,Review}
+
+    result = Dict{Symbol,Review}()
     counter = 0
 
     while counter < lines && !eof(io)
-        line = readline(io)
-        json = JSON.parse(line)
+        line = codeunits(readline(io))
+        a1 = view(line,1:(nth(',',line,7)-1))
+        a2 = view(line,nth(',',line,1,true):length(line))
+
+        json = JSON.parse(String(vcat(a1,a2)))
+        id = Symbol(json["review_id"])
         b = Review(
-            json["review_id"],
-            json["user_id"],
-            json["business_id"],
+            id,
+            Symbol(json["user_id"]),
+            Symbol(json["business_id"]),
             json["stars"],
-            json["date"],
+            DateTime(json["date"],dateformat"yyyy-mm-dd HH:MM:SS"),
             json["useful"],
             json["funny"],
             json["cool"]
         )
-        push!(result,json["review_id"]=>b)
-
+        result[id]=b
         counter += 1
     end
     return result
 end
 
+function nth(what::Char,s::AbstractArray{UInt8},n::Int,reverse = false)
+    c = UInt8(what)
+    count = 0
+    for ix::Int in (reverse ? (length(s):-1:1) : (1:length(s)) )
+        (s[ix] == c) && (count += 1)
+        count >= n && return ix
+    end
+    return -1
+end
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test
 using HypergraphsYelp
 using SimpleHypergraphs
 using LightGraphs
-
+using Dates
 
 
 const testdir = dirname(@__FILE__)
@@ -12,29 +12,29 @@ tests = [
     #"",
 ]
 
-b1 = Business("1","r1","napoli","italy",0.0,0.0,2.0,0,Array{AbstractString,1}())
-b2 = Business("2","r2","avellino","italy",0.0,0.0,3.0,0,Array{AbstractString,1}())
-b3 = Business("3","r3","caserta","italy",0.0,0.0,3.0,0,Array{AbstractString,1}())
-b4 = Business("4","r4","napoli","italy",0.0,0.0,2.5,0,Array{AbstractString,1}())
-b5 = Business("5","r5","avellino","italy",0.0,0.0,2.0,0,Array{AbstractString,1}())
+b1 = Business(:a,:r1,:napoli,:italy,0.0,0.0,2.0,0,Symbol[])
+b2 = Business(:b,:r2,:avellino,:italy,0.0,0.0,3.0,0,Symbol[])
+b3 = Business(:c,:r3,:caserta,:italy,0.0,0.0,3.0,0,Symbol[])
+b4 = Business(:d,:r4,:napoli,:italy,0.0,0.0,2.5,0,Symbol[])
+b5 = Business(:e,:r5,:avellino,:italy,0.0,0.0,2.0,0,Symbol[])
 
 
-u1 = User("1","bob",0,0,0,Array{AbstractString,1}())
-u2 = User("2","alice",0,0,0,Array{AbstractString,1}())
+u1 = User(:a,0,0,0,Symbol[])
+u2 = User(:b,0,0,0,Symbol[])
 
-r1 = Review("1",u1.id,b1.id,3.0,"",0,0,0)
-r2 = Review("2",u1.id,b2.id,3.0,"",0,0,0)
-r3 = Review("3",u1.id,b3.id,3.0,"",0,0,0)
-r4 = Review("4",u1.id,b4.id,3.0,"",0,0,0)
+r1 = Review(:a,u1.id,b1.id,3.0,now(),0,0,0)
+r2 = Review(:b,u1.id,b2.id,3.0,now(),0,0,0)
+r3 = Review(:c,u1.id,b3.id,3.0,now(),0,0,0)
+r4 = Review(:d,u1.id,b4.id,3.0,now(),0,0,0)
 
-r5 = Review("5",u2.id,b1.id,2.0,"",0,0,0)
-r6 = Review("6",u2.id,b4.id,2.0,"",0,0,0)
-r7 = Review("7",u2.id,b5.id,2.0,"",0,0,0)
+r5 = Review(:e,u2.id,b1.id,2.0,now(),0,0,0)
+r6 = Review(:f,u2.id,b4.id,2.0,now(),0,0,0)
+r7 = Review(:g,u2.id,b5.id,2.0,now(),0,0,0)
 
 
-businesses = Dict{String,Business}()
-users = Dict{String,User}()
-reviews = Dict{String,Review}()
+businesses = Dict{Symbol,Business}()
+users = Dict{Symbol,User}()
+reviews = Dict{Symbol,Review}()
 
 push!(businesses,b1.id=>b1)
 push!(businesses,b2.id=>b2)


### PR DESCRIPTION
Performance improvements for reading Yelp dataset.

Currently reading into the memory the entire 8GB dataset requires 3.5GB of free memory and takes 8 minutes.

Main changes:
 - avoid abstract types (including `Real`)
 - for keys use `Symbol`s instead of `String`s - much less memory is consumed (String representing symbol is stored only once in the memory) and comparisons are much cheaper (`Int`s are compared instead of `String`s )
- minor improvement in handling the biggest file

All tests in the `test` folder pass successfully.

